### PR TITLE
add basic ui for submission page #52 N2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "tabWidth": 4,
+  "tabWidth": 2,
   "useTabs": false,
   "overrides": [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,12 @@
 {
-  "tabWidth": 2,
-  "useTabs": false
+  "tabWidth": 4,
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": ["*.tsx"],
+      "options": {
+        "tabWidth": 2
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "axios": "^1.5.1",
     "bcrypt": "^5.1.1",
     "concurrently": "^8.2.1",
+    "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "dotenv-cli": "^7.3.0",
     "nanoid": "3.0.0",

--- a/prisma/mongodb/schema.prisma
+++ b/prisma/mongodb/schema.prisma
@@ -27,15 +27,15 @@ model Environment {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    languageId Int      // from Judge0
+    languageId Int // from Judge0
     Question   Question @relation(fields: [questionId], references: [id])
     questionId String
 
-    template    String
-    prepend     String?
-    append      String?
-    testCases   TestCase[]
-    answers     Answer[]
+    template  String
+    prepend   String?
+    append    String?
+    testCases TestCase[]
+    answers   Answer[]
 
     @@unique([languageId, questionId])
 }
@@ -45,7 +45,7 @@ model TestCase {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    Environment Environment @relation(fields: [environmentId], references: [id])
+    Environment   Environment @relation(fields: [environmentId], references: [id])
     environmentId String
 
     description String
@@ -54,16 +54,15 @@ model TestCase {
     test        String
     input       String?
     output      String?
-    timeLimit   Float?  // in seconds
-    memoryLimit Float?  // in kilobytes
+    timeLimit   Float? // in seconds
+    memoryLimit Float? // in kilobytes
 }
 
 model Answer {
-    id        String   @id @default(cuid()) @map("_id")
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
-    body      String
-    environment  Environment @relation(fields: [envId], references: [id])
-    envId String
-
+    id          String      @id @default(cuid()) @map("_id")
+    createdAt   DateTime    @default(now())
+    updatedAt   DateTime    @updatedAt
+    body        String
+    environment Environment @relation(fields: [envId], references: [id])
+    envId       String
 }

--- a/prisma/postgres/schema.prisma
+++ b/prisma/postgres/schema.prisma
@@ -123,34 +123,32 @@ model VerificationToken {
 }
 
 model MatchRequest {
-    id          String  @id
-    name        String?
-    difficulty  Int
-    category    String
+    id         String  @id
+    name       String?
+    difficulty Int
+    category   String
 }
 
 model JoinRequest {
-    id          Int     @id @default(autoincrement())
-    fromName    String
-    fromId      String
-    toId        String
+    id       Int    @id @default(autoincrement())
+    fromName String
+    fromId   String
+    toId     String
 
     @@unique([fromId, toId])
-
     @@index([fromId])
-    @@index([toId]) 
+    @@index([toId])
 }
-
 
 model QuestionAttempt {
     userId      String
     questionId  String
+    language    String
     answerId    String
-    attemptedOn DateTime @default(now())
+    attemptedOn DateTime     @default(now())
     // storing result in postgres because its easier to access if we want to list the results
-    result      AnswerResult 
-    user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+    result      AnswerResult
+    user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     @@unique([userId, questionId, answerId])
-
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,9 +3,7 @@ import { type PropsWithChildren } from "react";
 export const PageLayout = (props: PropsWithChildren) => {
   return (
     <main className="flex h-screen justify-center bg-slate-900 text-slate-100 overflow-auto">
-      <div className="h-full w-full md:max-w-2xl">
-        {props.children}
-      </div>
+      <div className="h-full w-full md:max-w-2xl">{props.children}</div>
     </main>
   );
 };

--- a/src/components/QuestionSubmissions.tsx
+++ b/src/components/QuestionSubmissions.tsx
@@ -1,0 +1,101 @@
+import Head from "next/head";
+import router, { useRouter } from "next/router";
+import { PageLayout } from "~/components/Layout";
+import { api } from "~/utils/api";
+import { useSession } from "next-auth/react";
+import { LoadingPage } from "~/components/Loading";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
+
+// TODO: modify to return submissions of a specific question
+// maybe of a specifc user (depending on where you want user to be able
+// to view all submission to a questions or just their submission)
+const QuestionSubmissions = ({ userId }: { userId: string }) => {
+  // session is `null` until nextauth fetches user's session data
+  const { data: session } = useSession({
+    required: true,
+    onUnauthenticated() {
+      void router.push("/sign-in");
+    },
+  });
+
+  // MOCK DATA remove when tested with real data
+  const mockDate = new Date("2022-12-17T03:24:00");
+  const mockUserSubmissions = [
+    {
+      questionTitle: "Some Question Title",
+      answerId: "1",
+      attemptedOn: mockDate,
+      result: "ACCEPTED",
+    },
+    {
+      questionTitle: "Some Question Title",
+      answerId: "1",
+      attemptedOn: mockDate,
+      result: "WRONG_ANSWER",
+    },
+  ];
+
+  // const { data: userSubmissions = [], isLoading: userSubmissionsLoading } =
+  //   api.answer.getUserSubmissionsOfQuestion.useQuery();
+
+  // if (!session || userSubmissionsLoading) {
+  //   return (
+  //     <>
+  //       <Head>
+  //         <title>Profile</title>
+  //       </Head>
+  //       <PageLayout>
+  //         <LoadingPage />
+  //       </PageLayout>
+  //     </>
+  //   );
+  // }
+
+  return (
+    <>
+      <Head>
+        <title>Profile</title>
+      </Head>
+      <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
+        <div className="relative overflow-x-auto">
+          <div className="py-4">All my submissions</div>
+          <table className="w-full text-sm text-left text-gray-500 dark:text-slate-300">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-slate-200">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  Time Submitted
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Question
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Status
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Language
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+              {/* {userSubmissions.map((submission) => ( */}
+              {mockUserSubmissions.map((submission) => (
+                <tr>
+                  <td className="px-6 py-4">
+                    {dayjs(submission.attemptedOn).fromNow()}
+                  </td>
+                  <td className="px-6 py-4">{submission.questionTitle}</td>
+                  <td className="px-6 py-4">{submission.result}</td>
+                  <td className="px-6 py-4">Python 3</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default QuestionSubmissions;

--- a/src/components/QuestionSubmissions.tsx
+++ b/src/components/QuestionSubmissions.tsx
@@ -1,9 +1,6 @@
 import Head from "next/head";
-import router, { useRouter } from "next/router";
-import { PageLayout } from "~/components/Layout";
-import { api } from "~/utils/api";
+import router from "next/router";
 import { useSession } from "next-auth/react";
-import { LoadingPage } from "~/components/Loading";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 dayjs.extend(relativeTime);

--- a/src/pages/profile/account.tsx
+++ b/src/pages/profile/account.tsx
@@ -11,6 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { signOut, useSession } from "next-auth/react";
 import { LoadingPage } from "~/components/Loading";
+import QuestionSubmissions from "~/components/QuestionSubmissions";
 
 // TODO:
 // - add email verification
@@ -32,7 +33,6 @@ const ProfilePage: NextPage = () => {
     onUnauthenticated() {
       void router.push("/sign-in");
     },
-    // defaults redirects user to sign in page if not signed in
   });
 
   const updateInfoSchema = z.object({
@@ -253,6 +253,17 @@ const ProfilePage: NextPage = () => {
               </div>
             </>
           )}
+        </div>
+        <div className="border-b border-slate-100"></div>
+        <div className="p-4">
+          <div className="font-bold pb-2">
+            <button
+              className="font-medium text-slate-300 hover:underline dark:text-slate-400"
+              onClick={() => router.push("/submissions")}
+            >
+              View all submissions
+            </button>
+          </div>
         </div>
       </PageLayout>
     </>

--- a/src/pages/submissions/detail/[id].tsx
+++ b/src/pages/submissions/detail/[id].tsx
@@ -18,12 +18,6 @@ const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
   const { data: submission, isLoading } = api.answer.getAnswerBody.useQuery({
     answerId: props.submissionId,
   });
-  //   const { data: languages, isLoading: isLanguagesLoading } = api.judge.getLanguages.useQuery(undefined, {
-  //     onError: (e) => {
-  //       toast.error("Failed to fetch language: " + e.message);
-  //     },
-  //   });
-  //   const language = languages?.find((l) => l.id === data.envlanguageId
 
   if (isLoading) {
     return (
@@ -46,7 +40,7 @@ const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
       <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
         <div className="relative overflow-x-auto">
           {MOCK_SUBMISSION ? (
-            <div>{MOCK_SUBMISSION.body}</div>
+            <code>{MOCK_SUBMISSION.body}</code>
           ) : (
             <div>submission not found</div>
           )}

--- a/src/pages/submissions/detail/[id].tsx
+++ b/src/pages/submissions/detail/[id].tsx
@@ -1,0 +1,59 @@
+import { type NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import toast from "react-hot-toast";
+import { PageLayout } from "~/components/Layout";
+import { LoadingPage } from "~/components/Loading";
+import { api } from "~/utils/api";
+
+const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
+  const { query } = useRouter();
+  const id = query.id ?? "";
+  if (typeof id != "string") {
+    throw new Error("invalid submission id: slug is not a string");
+  }
+
+  // mockdata
+  const MOCK_SUBMISSION = { body: "def sum(x,y): return x+y" };
+  const { data: submission, isLoading } = api.answer.getAnswerBody.useQuery({
+    answerId: props.submissionId,
+  });
+  //   const { data: languages, isLoading: isLanguagesLoading } = api.judge.getLanguages.useQuery(undefined, {
+  //     onError: (e) => {
+  //       toast.error("Failed to fetch language: " + e.message);
+  //     },
+  //   });
+  //   const language = languages?.find((l) => l.id === data.envlanguageId
+
+  if (isLoading) {
+    return (
+      <>
+        <Head>
+          <title>Submission Detail</title>
+        </Head>
+        <PageLayout>
+          <LoadingPage />
+        </PageLayout>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Submission Detail</title>
+      </Head>
+      <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
+        <div className="relative overflow-x-auto">
+          {MOCK_SUBMISSION ? (
+            <div>{MOCK_SUBMISSION.body}</div>
+          ) : (
+            <div>submission not found</div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default SingleSubmissionDetailPage;

--- a/src/pages/submissions/detail/[id].tsx
+++ b/src/pages/submissions/detail/[id].tsx
@@ -1,7 +1,5 @@
-import { type NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import toast from "react-hot-toast";
 import { PageLayout } from "~/components/Layout";
 import { LoadingPage } from "~/components/Loading";
 import { api } from "~/utils/api";
@@ -13,8 +11,9 @@ const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
     throw new Error("invalid submission id: slug is not a string");
   }
 
-  // mockdata
-  const MOCK_SUBMISSION = { body: "def sum(x,y): return x+y" };
+  // TODO: remove mockdata
+  // const MOCK_SUBMISSION = { body: "def sum(x,y): return x+y" };
+
   const { data: submission, isLoading } = api.answer.getAnswerBody.useQuery({
     answerId: props.submissionId,
   });
@@ -32,6 +31,21 @@ const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
     );
   }
 
+  if (!submission) {
+    return (
+      <>
+        <Head>
+          <title>Submission Detail</title>
+        </Head>
+        <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
+          <div className="relative overflow-x-auto">
+            <div>Error 404 not found</div>
+          </div>
+        </main>
+      </>
+    );
+  }
+
   return (
     <>
       <Head>
@@ -39,11 +53,16 @@ const SingleSubmissionDetailPage = (props: { submissionId: string }) => {
       </Head>
       <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
         <div className="relative overflow-x-auto">
-          {MOCK_SUBMISSION ? (
-            <code>{MOCK_SUBMISSION.body}</code>
-          ) : (
-            <div>submission not found</div>
-          )}
+          <label className="w-full mb-10 flex-1 block text-sm font-medium text-gray-900 dark:text-white">
+            Code
+            <textarea
+              name="source_code"
+              id="source_code"
+              className="mt-3 h-full min-h-[10rem] w-full p-2 font-mono box-border bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white "
+              value={submission.body}
+              readOnly
+            />
+          </label>
         </div>
       </main>
     </>

--- a/src/pages/submissions/index.tsx
+++ b/src/pages/submissions/index.tsx
@@ -25,12 +25,14 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
       answerId: "1",
       attemptedOn: mockDate,
       result: "ACCEPTED",
+      language: "Python 3",
     },
     {
       questionTitle: "Some Question Title",
       answerId: "1",
       attemptedOn: mockDate,
       result: "WRONG_ANSWER",
+      language: "Python 3",
     },
   ];
 
@@ -95,7 +97,7 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
                       {submission.result}
                     </button>
                   </td>
-                  <td className="px-6 py-4">Python 3</td>
+                  <td className="px-6 py-4">{submission.language}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/submissions/index.tsx
+++ b/src/pages/submissions/index.tsx
@@ -1,0 +1,98 @@
+import Head from "next/head";
+import router, { useRouter } from "next/router";
+import { PageLayout } from "~/components/Layout";
+import { api } from "~/utils/api";
+import { useSession } from "next-auth/react";
+import { LoadingPage } from "~/components/Loading";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
+
+const UserSubmissions = ({ userId }: { userId: string }) => {
+  // session is `null` until nextauth fetches user's session data
+  const { data: session } = useSession({
+    required: true,
+    onUnauthenticated() {
+      void router.push("/sign-in");
+    },
+  });
+
+  // MOCK DATA remove when tested with real data
+  const mockDate = new Date("2022-12-17T03:24:00");
+  const mockUserSubmissions = [
+    {
+      questionTitle: "Some Question Title",
+      answerId: "1",
+      attemptedOn: mockDate,
+      result: "ACCEPTED",
+    },
+    {
+      questionTitle: "Some Question Title",
+      answerId: "1",
+      attemptedOn: mockDate,
+      result: "WRONG_ANSWER",
+    },
+  ];
+
+  const { data: userSubmissions = [], isLoading: userSubmissionsLoading } =
+    api.answer.getUserSubmissions.useQuery();
+
+  if (!session || userSubmissionsLoading) {
+    return (
+      <>
+        <Head>
+          <title>Profile</title>
+        </Head>
+        <PageLayout>
+          <LoadingPage />
+        </PageLayout>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Profile</title>
+      </Head>
+      <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
+        <div className="relative overflow-x-auto">
+          <div className="py-4">All my submissions</div>
+          <table className="w-full text-sm text-left text-gray-500 dark:text-slate-300">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-slate-200">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  Time Submitted
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Question
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Status
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Language
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+              {/* {userSubmissions.map((submission) => ( */}
+              {mockUserSubmissions.map((submission) => (
+                <tr>
+                  <td className="px-6 py-4">
+                    {dayjs(submission.attemptedOn).fromNow()}
+                  </td>
+                  <td className="px-6 py-4">{submission.questionTitle}</td>
+                  <td className="px-6 py-4">{submission.result}</td>
+                  <td className="px-6 py-4">Python 3</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default UserSubmissions;

--- a/src/pages/submissions/index.tsx
+++ b/src/pages/submissions/index.tsx
@@ -41,7 +41,7 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
     return (
       <>
         <Head>
-          <title>Profile</title>
+          <title>Submission</title>
         </Head>
         <PageLayout>
           <LoadingPage />
@@ -53,13 +53,13 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
   return (
     <>
       <Head>
-        <title>Profile</title>
+        <title>Submission</title>
       </Head>
       <main className="h-screen bg-slate-900 text-slate-100 overflow-auto p-3">
         <div className="relative overflow-x-auto">
           <div className="py-4">All my submissions</div>
           <table className="w-full text-sm text-left text-gray-500 dark:text-slate-300">
-            <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-slate-200">
+            <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-slate-700 dark:text-slate-200">
               <tr>
                 <th scope="col" className="px-6 py-3">
                   Time Submitted
@@ -78,12 +78,23 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
             <tbody className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
               {/* {userSubmissions.map((submission) => ( */}
               {mockUserSubmissions.map((submission) => (
-                <tr>
+                <tr className="hover:bg-gray-700">
                   <td className="px-6 py-4">
                     {dayjs(submission.attemptedOn).fromNow()}
                   </td>
                   <td className="px-6 py-4">{submission.questionTitle}</td>
-                  <td className="px-6 py-4">{submission.result}</td>
+                  <td className="px-6 py-4">
+                    <button
+                      className="hover:underline"
+                      onClick={() =>
+                        router.push(
+                          `/submissions/detail/${submission.answerId}`,
+                        )
+                      }
+                    >
+                      {submission.result}
+                    </button>
+                  </td>
                   <td className="px-6 py-4">Python 3</td>
                 </tr>
               ))}

--- a/src/pages/submissions/index.tsx
+++ b/src/pages/submissions/index.tsx
@@ -18,23 +18,23 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
   });
 
   // MOCK DATA remove when tested with real data
-  const mockDate = new Date("2022-12-17T03:24:00");
-  const mockUserSubmissions = [
-    {
-      questionTitle: "Some Question Title",
-      answerId: "1",
-      attemptedOn: mockDate,
-      result: "ACCEPTED",
-      language: "Python 3",
-    },
-    {
-      questionTitle: "Some Question Title",
-      answerId: "1",
-      attemptedOn: mockDate,
-      result: "WRONG_ANSWER",
-      language: "Python 3",
-    },
-  ];
+  // const mockDate = new Date("2022-12-17T03:24:00");
+  // const mockUserSubmissions = [
+  //   {
+  //     questionTitle: "Some Question Title",
+  //     answerId: "1",
+  //     attemptedOn: mockDate,
+  //     result: "ACCEPTED",
+  //     language: "Python 3",
+  //   },
+  //   {
+  //     questionTitle: "Some Question Title",
+  //     answerId: "1",
+  //     attemptedOn: mockDate,
+  //     result: "WRONG_ANSWER",
+  //     language: "Python 3",
+  //   },
+  // ];
 
   const { data: userSubmissions = [], isLoading: userSubmissionsLoading } =
     api.answer.getUserSubmissions.useQuery();
@@ -78,8 +78,7 @@ const UserSubmissions = ({ userId }: { userId: string }) => {
               </tr>
             </thead>
             <tbody className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
-              {/* {userSubmissions.map((submission) => ( */}
-              {mockUserSubmissions.map((submission) => (
+              {userSubmissions.map((submission) => (
                 <tr className="hover:bg-gray-700">
                   <td className="px-6 py-4">
                     {dayjs(submission.attemptedOn).fromNow()}

--- a/src/server/api/routers/answer.ts
+++ b/src/server/api/routers/answer.ts
@@ -1,166 +1,183 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import {
-    PrismaMongoT,
-    prismaMongo,
-    prismaPostgres,
-    PrismaPostgresT,
+  PrismaMongoT,
+  prismaMongo,
+  prismaPostgres,
+  PrismaPostgresT,
 } from "~/server/db";
 import type { AnswerResult } from "@prisma-db-psql/client";
 import type { Answer } from "@prisma-db-mongo/client";
 import { TRPCError } from "@trpc/server";
 import { appRouter } from "../root";
 import { Session } from "next-auth";
+import { api } from "~/utils/api";
 
 const createAnswerInput = z.object({
-    body: z.string(),
-    userId: z.string(),
-    environmentId: z.string(),
+  body: z.string(),
+  userId: z.string(),
+  environmentId: z.string(),
 });
 async function runAnswer(
-    answer: Answer,
-    ctx: {
-        session: Session | null;
-        prismaPostgres: PrismaPostgresT;
-        prismaMongo: PrismaMongoT;
-    },
+  answer: Answer,
+  ctx: {
+    session: Session | null;
+    prismaPostgres: PrismaPostgresT;
+    prismaMongo: PrismaMongoT;
+  },
 ): Promise<{
-    ans: AnswerResult;
+  ans: AnswerResult;
 }> {
-    const testCases = await prismaMongo.testCase.findMany({
-        where: {
-            environmentId: answer.envId,
-        },
-    });
-    let allCorrect = true;
+  const testCases = await prismaMongo.testCase.findMany({
+    where: {
+      environmentId: answer.envId,
+    },
+  });
+  let allCorrect = true;
 
-    const caller = appRouter.createCaller(ctx);
-    // todo: create  sumission batch
-    for (const testCase of testCases) {
-        const result = await caller.judge.runTestCase({
-            testCaseId: testCase.id,
-            source_code: answer.body,
-        });
-        if (result.status.id !== 3) {
-            allCorrect = false;
-        }
+  const caller = appRouter.createCaller(ctx);
+  // todo: create  sumission batch
+  for (const testCase of testCases) {
+    const result = await caller.judge.runTestCase({
+      testCaseId: testCase.id,
+      source_code: answer.body,
+    });
+    if (result.status.id !== 3) {
+      allCorrect = false;
     }
-    // todo: support other fields
-    return {
-        ans: allCorrect ? "ACCEPTED" : "WRONG_ANSWER",
-    };
+  }
+  // todo: support other fields
+  return {
+    ans: allCorrect ? "ACCEPTED" : "WRONG_ANSWER",
+  };
 }
 
 const answerRouter = createTRPCRouter({
-    /**
-     * Route used to submit answers
-     */
-    submitAnswer: protectedProcedure
-        .input(createAnswerInput)
-        .mutation(async ({ ctx, input }) => {
-            const { body, environmentId } = input;
-            const user = ctx.session.user;
-            const env = await prismaMongo.environment.findUnique({
-                where: {
-                    id: input.environmentId,
-                },
-            });
-            if (!env)
-                throw new TRPCError({
-                    code: "BAD_REQUEST",
-                    message: "Invalid environment",
-                });
-            const answer = await prismaMongo.answer.create({
-                data: {
-                    body,
-                    envId: environmentId,
-                },
-            });
-            // todo: generate the result from using some kind of code execution
-            const result = await runAnswer(answer, ctx);
-            const userAnswer = await prismaPostgres.questionAttempt.create({
-                data: {
-                    answerId: answer.id,
-                    questionId: env?.questionId,
-                    userId: user.id,
-                    result: result.ans,
-                },
-            });
-            return userAnswer;
-        }),
-
-    getUserSubmissions: protectedProcedure.query(async ({ ctx }) => {
-        const user = ctx.session.user;
-        const submissions = await prismaPostgres.questionAttempt.findMany({
-            where: {
-                userId: user.id,
-            },
+  /**
+   * Route used to submit answers
+   */
+  submitAnswer: protectedProcedure
+    .input(createAnswerInput)
+    .mutation(async ({ ctx, input }) => {
+      const { body, environmentId } = input;
+      const user = ctx.session.user;
+      const env = await prismaMongo.environment.findUnique({
+        where: {
+          id: input.environmentId,
+        },
+      });
+      if (!env)
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid environment",
         });
+      const answer = await prismaMongo.answer.create({
+        data: {
+          body,
+          envId: environmentId,
+        },
+      });
 
-        const submissionsWithTitle = submissions.map(async (submission) => {
-            const question = await prismaMongo.question.findUnique({
-                where: { id: submission.questionId },
-            });
-            if (!question) {
-                throw new TRPCError({
-                    code: "BAD_REQUEST",
-                    message: "Failed to find question",
-                });
-            }
-
-            const { questionId, userId, ...filteredSubmission } = submission;
-            return {
-                ...filteredSubmission,
-                questionTitle: question.title,
-            };
+      const languages = await api.judge.getLanguages.useQuery().data;
+      const language = languages?.find((l) => l.id === env.languageId)?.name;
+      if (!language) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid language",
         });
+      }
 
-        return await Promise.all(submissionsWithTitle);
+      // todo: generate the result from using some kind of code execution
+      const result = await runAnswer(answer, ctx);
+      const userAnswer = await prismaPostgres.questionAttempt.create({
+        data: {
+          answerId: answer.id,
+          questionId: env?.questionId,
+          language: language,
+          userId: user.id,
+          result: result.ans,
+        },
+      });
+      return userAnswer;
     }),
 
-    getUserSubmissionsOfQuestion: protectedProcedure
-        .input(z.object({ questionId: z.string() }))
-        .query(async ({ ctx, input }) => {
-            const user = ctx.session.user;
-            return await prismaPostgres.questionAttempt.findMany({
-                where: {
-                    userId: user.id,
-                    questionId: input.questionId,
-                },
-            });
-        }),
+  getUserSubmissions: protectedProcedure.query(async ({ ctx }) => {
+    const user = ctx.session.user;
+    const submissions = await prismaPostgres.questionAttempt.findMany({
+      where: {
+        userId: user.id,
+      },
+    });
 
-    getAnswerBody: protectedProcedure
-        .input(z.object({ answerId: z.string(), questionId: z.string() }))
-        .query(async ({ ctx, input }) => {
-            const user = ctx.session.user;
-            const attempt = await prismaPostgres.questionAttempt.findUnique({
-                where: {
-                    userId_questionId_answerId: {
-                        userId: user.id,
-                        questionId: input.questionId,
-                        answerId: input.answerId,
-                    },
-                },
-            });
-            if (!attempt) {
-                throw new TRPCError({
-                    code: "UNAUTHORIZED",
-                    message: "Not authorised for this answer",
-                });
-            }
-            const result = await prismaMongo.answer.findUnique({
-                where: {
-                    id: input.answerId,
-                },
-            });
-            if (!result)
-                throw new TRPCError({
-                    code: "BAD_REQUEST",
-                    message: "Failed to find answer",
-                });
-            return result;
-        }),
+    const submissionsWithTitle = Promise.all(
+      submissions.map(async (submission) => {
+        const question = await prismaMongo.question.findUnique({
+          where: { id: submission.questionId },
+        });
+        if (!question) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Failed to find question",
+          });
+        }
+
+        const { questionId, userId, ...filteredSubmission } = submission;
+        return {
+          ...filteredSubmission,
+          questionTitle: question.title,
+        };
+      }),
+    );
+
+    return await submissionsWithTitle;
+  }),
+
+  getUserSubmissionsOfQuestion: protectedProcedure
+    .input(z.object({ questionId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const user = ctx.session.user;
+      return await prismaPostgres.questionAttempt.findMany({
+        where: {
+          userId: user.id,
+          questionId: input.questionId,
+        },
+      });
+    }),
+
+  getAnswerBody: protectedProcedure
+    .input(
+      z.object({
+        answerId: z.string(),
+        // questionId: z.string(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      //   const user = ctx.session.user;
+      //   const attempt = await prismaPostgres.questionAttempt.findUnique({
+      //     where: {
+      //       userId_questionId_answerId: {
+      //         userId: user.id,
+      //         questionId: input.questionId,
+      //         answerId: input.answerId,
+      //       },
+      //     },
+      //   });
+      //   if (!attempt) {
+      //     throw new TRPCError({
+      //       code: "UNAUTHORIZED",
+      //       message: "Not authorised for this answer",
+      //     });
+      //   }
+      const result = await prismaMongo.answer.findUnique({
+        where: { id: input.answerId },
+      });
+      if (!result)
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Failed to find answer",
+        });
+      return result;
+    }),
 });
 
 export default answerRouter;

--- a/src/server/api/routers/answer.ts
+++ b/src/server/api/routers/answer.ts
@@ -12,6 +12,7 @@ import { TRPCError } from "@trpc/server";
 import { appRouter } from "../root";
 import { Session } from "next-auth";
 import { api } from "~/utils/api";
+import axios from "axios";
 
 const createAnswerInput = z.object({
   body: z.string(),
@@ -78,7 +79,11 @@ const answerRouter = createTRPCRouter({
         },
       });
 
-      const languages = await api.judge.getLanguages.useQuery().data;
+      const languages = await axios
+        .get("http://localhost:2358/languages")
+        .then((res) => {
+          return res.data as { id: number; name: string }[];
+        });
       const language = languages?.find((l) => l.id === env.languageId)?.name;
       if (!language) {
         throw new TRPCError({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,6 +3121,11 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+dayjs@^1.11.10:
+  version "1.11.10"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
+
 debug@4, debug@^4.0.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"


### PR DESCRIPTION
sorry the the diffs for `answer.ts` is a bit hard to see because auto formatted on save.
 
only logic change was adding (`questionTitle`) field to api return of `getUserSubmissions`, also filtering out fields (`questionId`, `userId`).
- 'answers' was renamed to 'submission' for some api because terminology was quite confusing, i wan unsure if its the actual answer or the user answer, I referenced leetcode submissions page https://leetcode.com/submissions/#/1

TODO: 
- try modify api to return language as well

**Modified logic in answer.ts api**
``` getUserSubmissions: protectedProcedure.query(async ({ ctx }) => {
        const user = ctx.session.user;
        const submissions = await prismaPostgres.questionAttempt.findMany({
            where: {
                userId: user.id,
            },
        });

        const submissionsWithTitle = submissions.map(async (submission) => {
            const question = await prismaMongo.question.findUnique({
                where: { id: submission.questionId },
            });
            if (!question) {
                throw new TRPCError({
                    code: "BAD_REQUEST",
                    message: "Failed to find question",
                });
            }

            const { questionId, userId, ...filteredSubmission } = submission;
            return {
                ...filteredSubmission,
                questionTitle: question.title,
            };
        });

        return await Promise.all(submissionsWithTitle);
    }),
```