### PR TITLE
collab page changes

### DIFF
--- a/src/hooks/useMatchUsers.ts
+++ b/src/hooks/useMatchUsers.ts
@@ -3,34 +3,36 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { api } from "~/utils/api";
 
-
 type UseMatchUsersResult = {
-    setMatchedUsers: (user1: string, user2: string) => void;
+  setMatchedUsers: (user1: string, user2: string) => void;
 };
 /**
  * Hook for matching users
- * @returns 
+ * @returns a function to set a pair of matched users
  */
 export default function useMatchUsers(): UseMatchUsersResult {
-    const { data: session } = useSession(); 
-    const matchedUsers = api.sharedSession.createSharedCodeSession.useMutation();
-    
-    const router = useRouter();
-    const matchUsersSubscription = api.sharedSession.sharedCodeSessionSubscription.useSubscription(undefined, {
-        onData(data) {
-            if (data.user1 === session?.user.id|| data.user2 === session?.user.id) {
-                console.log("Routing");
-                void router.push(`/collab/rooms/${data.sessionId}`);
-            }
+  const { data: session } = useSession();
+  const matchedUsers = api.sharedSession.createSharedCodeSession.useMutation();
+
+  const router = useRouter();
+  const matchUsersSubscription =
+    api.sharedSession.sharedCodeSessionSubscription.useSubscription(undefined, {
+      onData(data) {
+        if (
+          data.user1 === session?.user.id ||
+          data.user2 === session?.user.id
+        ) {
+          console.log("Routing");
+          void router.push(`/collab/rooms/${data.sessionId}`);
         }
+      },
     });
 
-    return {
-        setMatchedUsers(user1, user2) {
-            const smallerUser = user1 < user2 ? user1 : user2;
-            if (smallerUser === session?.user.id) return; // the larger user does the matching
-            matchedUsers.mutate({ user1, user2 });
-        }
-    }
-
+  return {
+    setMatchedUsers(user1, user2) {
+      const smallerUser = user1 < user2 ? user1 : user2;
+      if (smallerUser === session?.user.id) return; // the larger user does the matching
+      matchedUsers.mutate({ user1, user2 });
+    },
+  };
 }

--- a/src/pages/collab/index.tsx
+++ b/src/pages/collab/index.tsx
@@ -79,7 +79,7 @@ const MatchRequestPage = () => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (curUserMatchRequest) {
         e.preventDefault();
-        // void handleDeleteMatchRequest();
+        void handleDeleteMatchRequest();
       }
     };
 
@@ -619,28 +619,30 @@ const RequestStatus = (props: { matchType: MatchType }) => {
       ? "Finding a request for you"
       : "Pending request acceptance";
   return (
-    <div className="fixed top-0 w-full z-50 animate-pulse flex items-center justify-center p-5">
-      <div className="bg-slate-200 rounded-md text-slate-800 px-6 py-3 flex items-center">
-        <svg
-          className="animate-spin h-5 w-5 text-slate-600 mr-3"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          ></circle>
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-          ></path>
-        </svg>
-        {msg}
+    <div className="fixed top-0 left-0 translate-x-1/2 translate-y-1/2 w-1/2">
+      <div className="animate-pulse flex items-center justify-center">
+        <div className="bg-slate-200 rounded-md text-slate-800 px-6 py-3 flex items-center">
+          <svg
+            className="animate-spin h-5 w-5 text-slate-600 mr-3"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            ></path>
+          </svg>
+          {msg}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/collab/index.tsx
+++ b/src/pages/collab/index.tsx
@@ -36,41 +36,17 @@ const MatchRequestPage = () => {
     throw new Error("Session cannot be undefined since AuthWrapper wrapped");
   }
   const curUserId = session.user.id;
-  const timer = useRef<NodeJS.Timer | null>(null);
-  const [timerState, setTimerState] = useState({
-    isTimerActive: false,
-    waitingTime: 0,
-  });
-
-  useEffect(() => {
-    setTimerState({ waitingTime: 0, isTimerActive: false });
-    if (timerState.isTimerActive) {
-      if (!timer.current) {
-        timer.current = setInterval(() => {
-          setTimerState((prev) => ({
-            ...prev,
-            isTimerActive: true,
-            waitingTime: prev.waitingTime + 1,
-          }));
-        }, 1000);
-      }
-    }
-  }, []);
-
-  const startTimer = () => {
-    setTimerState((prev) => ({
-      ...prev,
-      isTimerActive: true,
-    }));
+  const intervalRef = useRef<NodeJS.Timer | null>(null);
+  const [time, setTime] = useState(0);
+  const resetTimer = () => {
+    intervalRef.current = setInterval(() => {
+      setTime((prev) => prev + 1);
+    }, 1000);
+    setTime(0);
   };
   const stopTimer = () => {
-    if (!timer.current) return;
-    clearInterval(timer.current);
-    setTimerState({
-      waitingTime: 0,
-      isTimerActive: false,
-    });
-    timer.current = null;
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    setTime(0);
   };
 
   // remove current request immediately on refresh or change of page
@@ -78,11 +54,8 @@ const MatchRequestPage = () => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (curUserMatchRequest) {
         e.preventDefault();
-        if (
-          confirm(
-            "Are you sure you want to leave this page? Request will be deleted",
-          )
-        ) {
+        // confirm("Are you sure you want to leave this page? Request will be deleted")
+        if (true) {
           void handleDeleteMatchRequest();
         }
       }
@@ -119,7 +92,7 @@ const MatchRequestPage = () => {
     api.matchRequest.createCurrentUserMatchRequest.useMutation({
       onSuccess() {
         setIsCreatingMatchRequest(false);
-        startTimer();
+        resetTimer();
         toast.success("Successfully created match request");
       },
       onError(err) {
@@ -140,7 +113,7 @@ const MatchRequestPage = () => {
     api.matchRequest.updateCurrentUserMatchRequest.useMutation({
       onSuccess() {
         toast.success("Successfully updated match request");
-        startTimer();
+        resetTimer();
         setIsEditingMatchRequest(false);
       },
     });
@@ -218,9 +191,9 @@ const MatchRequestPage = () => {
   };
 
   // TODO: add custom confirm modal / hot-toast confirm modal
-  if ((timerState.waitingTime = 300)) {
-    // void deleteMatchRequest();
-  }
+  // if ((timerState.waitingTime = 300)) {
+  // void deleteMatchRequest();
+  // }
 
   return (
     <>
@@ -234,7 +207,6 @@ const MatchRequestPage = () => {
         <div className="flex flex-col h-full items-center justify-center bg-slate-800 text-center">
           <div className="space-y-4">
             <div className="flex flex-row justify-between">
-              <div>{JSON.stringify(timerState)}</div>
               <div className="text-left">Find a practice partner</div>
               <div className="text-right">{`(${
                 numOfMatchRequests ?? 0

--- a/src/pages/collab/index.tsx
+++ b/src/pages/collab/index.tsx
@@ -22,8 +22,6 @@ import { LoadingSpinner } from "~/components/Loading";
 
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import { time } from "console";
-import { deleteAppClientCache } from "next/dist/server/lib/render-server";
 dayjs.extend(relativeTime);
 
 /**
@@ -45,6 +43,7 @@ const MatchRequestPage = () => {
   });
 
   useEffect(() => {
+    setTimerState({ waitingTime: 0, isTimerActive: false });
     if (timerState.isTimerActive) {
       if (!timer.current) {
         timer.current = setInterval(() => {
@@ -56,7 +55,7 @@ const MatchRequestPage = () => {
         }, 1000);
       }
     }
-  }, [timerState.isTimerActive]);
+  }, []);
 
   const startTimer = () => {
     setTimerState((prev) => ({
@@ -79,7 +78,13 @@ const MatchRequestPage = () => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (curUserMatchRequest) {
         e.preventDefault();
-        void handleDeleteMatchRequest();
+        if (
+          confirm(
+            "Are you sure you want to leave this page? Request will be deleted",
+          )
+        ) {
+          void handleDeleteMatchRequest();
+        }
       }
     };
 
@@ -212,12 +217,9 @@ const MatchRequestPage = () => {
     console.log("Joining session...");
   };
 
-  // TODO: replace confirms with a custom confirm modal
-  if (timerState.waitingTime > 300) {
-    const continueWaiting = confirm(
-      "You have been waiting for more than 5 minutes. Do you want to continue waiting?",
-    );
-    if (!continueWaiting) void deleteMatchRequest();
+  // TODO: add custom confirm modal / hot-toast confirm modal
+  if ((timerState.waitingTime = 300)) {
+    // void deleteMatchRequest();
   }
 
   return (
@@ -232,6 +234,7 @@ const MatchRequestPage = () => {
         <div className="flex flex-col h-full items-center justify-center bg-slate-800 text-center">
           <div className="space-y-4">
             <div className="flex flex-row justify-between">
+              <div>{JSON.stringify(timerState)}</div>
               <div className="text-left">Find a practice partner</div>
               <div className="text-right">{`(${
                 numOfMatchRequests ?? 0

--- a/src/pages/collab/index.tsx
+++ b/src/pages/collab/index.tsx
@@ -545,7 +545,7 @@ const UpdateMatchRequestForm = ({
     resolver: zodResolver(updateMatchRequestSchema),
   });
 
-  const onSubmit: SubmitHandler<CreateMatchRequestData> = (data) => {
+  const onSubmit: SubmitHandler<UpdateMatchRequestData> = (data) => {
     onUpdate(data);
   };
 

--- a/src/pages/collab/index.tsx
+++ b/src/pages/collab/index.tsx
@@ -250,6 +250,10 @@ const MatchRequestPage = () => {
                   <UpdateMatchRequestForm
                     onUpdate={(data) => handleUpdateRequest(data)}
                     handleCancel={() => setIsEditingMatchRequest(false)}
+                    curData={{
+                      category: curUserMatchRequest.category,
+                      difficulty: curUserMatchRequest.difficulty,
+                    }}
                   />
                 )}
               </>
@@ -519,14 +523,19 @@ const updateMatchRequestSchema = z.object({
   difficulty: z.enum(["EASY", "MEDIUM", "HARD"]),
   category: z.string().min(1),
 });
-type UpdateMatchRequestData = z.infer<typeof createMatchRequestSchema>;
+type UpdateMatchRequestData = Omit<
+  z.infer<typeof createMatchRequestSchema>,
+  "automaticMatching"
+>;
 type UpdateMatchRequestFormProps = {
   onUpdate: (data: UpdateMatchRequestData) => void;
   handleCancel: () => void;
+  curData: UpdateMatchRequestData;
 };
 const UpdateMatchRequestForm = ({
   onUpdate,
   handleCancel,
+  curData,
 }: UpdateMatchRequestFormProps) => {
   const {
     register,
@@ -571,6 +580,7 @@ const UpdateMatchRequestForm = ({
         <select
           className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm font-medium rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           {...register("difficulty")}
+          defaultValue={curData.difficulty}
         >
           {difficulties.map((difficulty) => (
             <option key={difficulty} value={difficulty}>
@@ -586,6 +596,7 @@ const UpdateMatchRequestForm = ({
         <input
           className="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           type="text"
+          defaultValue={curData.category}
           {...register("category")}
         />
         {errors.category && (


### PR DESCRIPTION
**Notes**
- referenced previous changes and KF about desired behaviour: [previousCollabPRChanges](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g39/pull/74/files#diff-7e3ab8ee60abefbae9bcae7e81e069b012ab8e2ab7bcda48a06f1e942d782a81)
- changes to useMatchedUsers is only prettier, i modified one line of comment and saved which triggered the formatter

**Behaviour**
- Request is removed on change of page / refresh
- Time is not shown (generally recommended to show time when time is definite for sense of progress but since we have opted to let users have their requests up indefinitely best not to show)
- Will do a confirm modal in another PR and replace the windows.confirm in `Collab` `Profile` and maybe `Questions` (on delete of qns)

### Description of current implementation of automatic matching 
@Gabau pls lemme know if i understood it wrongly
- done by gabriel but just explaining what i understand in case anyone else would like to review / know since its not conventional 
- mutex is used to prevent race conditions

1. Each user is subscribed to every single user’s request changes (add / remove / update)
2. Whenever it gets a change it refetches
    * GetCurrentUser
    * GetManualRequest
3. On getCurrentUser success
    *  An attempt to try to automaticMatch the user is sent ((using an api endpoint))
